### PR TITLE
feat: show coverage files alphabetically

### DIFF
--- a/coverage/index.html
+++ b/coverage/index.html
@@ -73,8 +73,8 @@
       if (srcRoot && !/^https?:/i.test(srcRoot)) srcRoot = '';
 
       let filesData = [];
-      let sortKey = 'linePct';
-      let sortAsc = false;
+      let sortKey = 'file';
+      let sortAsc = true;
 
       function status(msg){ statusEl.textContent = msg; }
 


### PR DESCRIPTION
## Summary
- Default coverage file list sorting to alphabetical order

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3596ae370832ab77c71addd02ad72