### PR TITLE
Show file coverage with highlighted source code

### DIFF
--- a/coverage/index.html
+++ b/coverage/index.html
@@ -22,6 +22,7 @@
       tr.details td { background:#f5f5f5; }
       td.num { text-align:right; }
       .missed-line { background:#fee; }
+      .hit-line { background:#efe; }
       pre { overflow:auto; }
       .code-line { display:block; }
       .code-line .ln { color:#888; display:inline-block; min-width:3em; }
@@ -362,20 +363,20 @@
             const res=await fetch(url);
             if(!res.ok) throw new Error('HTTP '+res.status);
             const text=await res.text();
-            srcDiv.innerHTML=renderSource(text, file.missed);
+            srcDiv.innerHTML=renderSource(text, file.lines);
           }catch(e){
             srcDiv.textContent='Failed to load source';
           }
         }
       }
 
-      function renderSource(text, missed){
+      function renderSource(text, lineHits){
         const lines=text.split(/\r?\n/);
-        const set=new Set(missed);
         const width=String(lines.length).length;
         const html=lines.map((line,i)=>{
           const num=String(i+1).padStart(width,' ');
-          const cls=set.has(i+1)?'missed-line':'';
+          const count=lineHits[i+1];
+          const cls=count===0? 'missed-line' : count>0? 'hit-line' : '';
           return `<span class="code-line ${cls}"><span class="ln">${num}</span> ${escapeHtml(line)}</span>`;
         }).join('\n');
         return `<pre>${html}</pre>`;
@@ -384,6 +385,10 @@
       async function load(){
         const pathVal=pathInput.value.trim();
         if(!pathVal){ status('Path required'); filesData=[]; renderSummary(); renderTable(); return; }
+        if(!params.get('srcRoot')){
+          const m=pathVal.match(/[\\/]([0-9a-f]{40})[\\/]lcov\.info$/);
+          srcRoot = m ? `https://raw.githubusercontent.com/gluesql/gluesql/${m[1]}/` : '';
+        }
         status('Loading...');
         try{
           const url=normalizePath(pathVal);


### PR DESCRIPTION
## Summary
- Highlight covered lines in green and uncovered lines in red within coverage viewer
- Auto-detect commit from LCOV path to fetch and display source code for each file

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a360f05240832a98cb16bde9cd695a