### PR TITLE
Right-align coverage table headers

### DIFF
--- a/coverage/index.html
+++ b/coverage/index.html
@@ -14,6 +14,7 @@
       .card { border:1px solid #ccc; border-radius:4px; padding:.5rem 1rem; min-width:120px; }
       table { width:100%; border-collapse:collapse; margin-top:1rem; }
       th, td { padding:.25rem .5rem; border-bottom:1px solid #ddd; text-align:left; }
+      th:not(:first-child) { text-align:right; }
       th { position:sticky; top:3.5rem; background:#f9f9f9; }
       th button { background:none; border:none; font:inherit; cursor:pointer; }
       th[aria-sort="ascending"]::after { content:" \25B2"; }


### PR DESCRIPTION
## Summary
- align coverage table header cells to the right for consistency with numeric content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a365e49738832aa5cb8d924080bd4d