### PR TITLE
Use padding for coverage lines

### DIFF
--- a/coverage/index.html
+++ b/coverage/index.html
@@ -25,7 +25,7 @@
       .missed-line { background:#fee; }
       .hit-line { background:#efe; }
       pre { overflow:auto; }
-      .code-line { display:block; }
+      .code-line { display:block; margin:0; padding:0.1rem 0; }
       .code-line .ln { color:#888; display:inline-block; min-width:3em; }
       tr.folder td.file { cursor:pointer; font-weight:bold; }
       tr.folder td.file::before { content:"▶ "; }


### PR DESCRIPTION
## Summary
- tighten code line spacing in coverage viewer by swapping margin for small padding

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e11e3c48832a9aa5433137acf064