### PR TITLE
Fix code-line spacing in coverage viewer

### DIFF
--- a/coverage/index.html
+++ b/coverage/index.html
@@ -378,8 +378,8 @@
           const num=String(i+1).padStart(width,' ');
           const count=lineHits[i+1];
           const cls=count===0? 'missed-line' : count>0? 'hit-line' : '';
-          return `<span class="code-line ${cls}"><span class="ln">${num}</span> ${escapeHtml(line)}</span>`;
-        }).join('\n');
+          return `<code class="code-line ${cls}"><span class="ln">${num}</span> ${escapeHtml(line)}</code>`;
+        }).join('');
         return `<pre>${html}</pre>`;
       }
 


### PR DESCRIPTION
## Summary
- ensure code-line elements do not insert blank lines by removing newline joins and using semantic `<code>` tags

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e39bd8f4832aab457295164650ea