### PR TITLE
style: enhance code block colors

### DIFF
--- a/book/highlight.css
+++ b/book/highlight.css
@@ -23,7 +23,7 @@
 .hljs-name,
 .hljs-selector-id,
 .hljs-selector-class {
-  color: #d70025;
+  color: #e60026;
 }
 
 /* Orange */
@@ -41,7 +41,7 @@
 .hljs-string,
 .hljs-symbol,
 .hljs-bullet {
-  color: #008200;
+  color: #006400;
 }
 
 /* Blue */
@@ -59,7 +59,7 @@
 .hljs {
   display: block;
   overflow-x: auto;
-  background: #f6f7f6;
+  background: #ffffff;
   color: #000;
 }
 
@@ -72,11 +72,11 @@
 }
 
 .hljs-addition {
-  color: #22863a;
-  background-color: #f0fff4;
+  color: #006400;
+  background-color: #e6ffe6;
 }
 
 .hljs-deletion {
-  color: #b31d28;
-  background-color: #ffeef0;
+  color: #cc0000;
+  background-color: #ffe6e9;
 }


### PR DESCRIPTION
## Summary
- brighten code block background for better contrast
- use more vivid green and red for syntax highlighting
- adjust diff colors for additions and deletions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e711fb94832a97d66cab7f666222