### PR TITLE
Apply 0xProto font to coverage code blocks

### DIFF
--- a/coverage/index.html
+++ b/coverage/index.html
@@ -11,6 +11,7 @@
         font-style: normal;
       }
       body { font-family: '0xProto', monospace; margin:0; padding-top:3.5rem; }
+      pre, code { font-family: '0xProto', monospace; }
       header { position:fixed; top:0; left:0; right:0; background:#fff; border-bottom:1px solid #ccc; padding:.5rem; display:flex; flex-wrap:wrap; align-items:center; gap:.5rem; z-index:1000; }
       header input[type=text]{ flex:1; min-width:200px; }
       header button{ padding:.25rem .5rem; }


### PR DESCRIPTION
## Summary
- Ensure coverage viewer's `pre` and `code` elements use the 0xProto font

## Testing
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ef3b1a58832aaf076184c2c8dc0a