### PR TITLE
feat: brighten coverage view colors

### DIFF
--- a/coverage/index.html
+++ b/coverage/index.html
@@ -10,7 +10,7 @@
         font-weight: normal;
         font-style: normal;
       }
-      body { font-family: '0xProto', monospace; margin:0; padding-top:3.5rem; }
+      body { font-family: '0xProto', monospace; margin:0; padding-top:3.5rem; background:#fff; }
       pre, code { font-family: '0xProto', monospace; }
       header { position:fixed; top:0; left:0; right:0; background:#fff; border-bottom:1px solid #ccc; padding:.5rem; display:flex; flex-wrap:wrap; align-items:center; gap:.5rem; z-index:1000; }
       header input[type=text]{ flex:1; min-width:200px; }
@@ -27,12 +27,12 @@
       th[aria-sort="ascending"]::after { content:" \25B2"; }
       th[aria-sort="descending"]::after { content:" \25BC"; }
       tr:hover { background:#f0f0f0; }
-      tr.details td { background:#f5f5f5; }
+      tr.details td { background:#fff; }
       td.num { text-align:right; }
-      .missed-line { background:#fee; }
-      .hit-line { background:#efe; }
-      tr.full-coverage { background:#dfd; }
-      tr.full-coverage:hover { background:#cfc; }
+      .missed-line { background:#ffcccc; }
+      .hit-line { background:#ccffcc; }
+      tr.full-coverage { background:#b3ffb3; }
+      tr.full-coverage:hover { background:#99ff99; }
       pre { overflow:auto; }
       .code-line { display:block; margin:0; padding:0.1rem 0; }
       .code-line .ln { color:#888; display:inline-block; min-width:3em; }


### PR DESCRIPTION
## Summary
- use a clean white background for the coverage viewer
- intensify hit/miss/full coverage highlights for better contrast

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f0462ccc832a8456deff38d5dd6c