### PR TITLE
Align file and directory labels in coverage table

### DIFF
--- a/coverage/index.html
+++ b/coverage/index.html
@@ -36,9 +36,10 @@
       pre { overflow:auto; }
       .code-line { display:block; margin:0; padding:0.1rem 0; }
       .code-line .ln { color:#888; display:inline-block; min-width:3em; }
+      td.file::before { content:""; display:inline-block; width:1.2em; text-align:center; }
       tr.folder td.file { cursor:pointer; font-weight:bold; }
-      tr.folder td.file::before { content:"▶ "; }
-      tr.folder.open td.file::before { content:"▼ "; }
+      tr.folder td.file::before { content:"▶"; }
+      tr.folder.open td.file::before { content:"▼"; }
       tr.open-file td { background:#e0f7ff; }
       tr.open-file + tr.details td { border-left:4px solid #a3d8ff; }
       @media (max-width:600px) { table { display:block; overflow-x:auto; white-space:nowrap; } th { top:0; } }


### PR DESCRIPTION
## Summary
- add placeholder styling so file names align with directory rows in coverage table

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f19a81d4832ab5c6121162b45cd1