### PR TITLE
chore: soften full coverage color

### DIFF
--- a/coverage/index.html
+++ b/coverage/index.html
@@ -31,8 +31,8 @@
       td.num { text-align:right; }
       .missed-line { background:#ffcccc; }
       .hit-line { background:#ccffcc; }
-      tr.full-coverage { background:#b3ffb3; }
-      tr.full-coverage:hover { background:#99ff99; }
+      tr.full-coverage { background:#ddffdd; }
+      tr.full-coverage:hover { background:#c5ffc5; }
       pre { overflow:auto; }
       .code-line { display:block; margin:0; padding:0.1rem 0; }
       .code-line .ln { color:#888; display:inline-block; min-width:3em; }


### PR DESCRIPTION
## Summary
- lighten 100% coverage row style for subtler green

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f2fb3678832a8558a8c8d8816153