### PR TITLE
Apply 0xProto font to coverage viewer elements

### DIFF
--- a/coverage/index.html
+++ b/coverage/index.html
@@ -10,8 +10,10 @@
         font-weight: normal;
         font-style: normal;
       }
-      body { font-family: '0xProto', monospace; margin:0; padding-top:3.5rem; background:#fff; }
-      pre, code { font-family: '0xProto', monospace; }
+      body, pre, code, input, button, select, textarea, header, main, div, span, table, th, td {
+        font-family: '0xProto', monospace;
+      }
+      body { margin:0; padding-top:3.5rem; background:#fff; }
       header { position:fixed; top:0; left:0; right:0; background:#fff; border-bottom:1px solid #ccc; padding:.5rem; display:flex; flex-wrap:wrap; align-items:center; gap:.5rem; z-index:1000; }
       header input[type=text], header input[type=file]{ flex:1; min-width:200px; }
       header button{ padding:.25rem .5rem; }


### PR DESCRIPTION
## Summary
- Ensure coverage viewer uses the 0xProto monospace font for all elements, including form controls and table components

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f7bec6c4832aba0a3b8b79b26797