### PR TITLE
chore: set coverage page max width

### DIFF
--- a/coverage/index.html
+++ b/coverage/index.html
@@ -14,11 +14,11 @@
         font-family: '0xProto', monospace;
       }
       body { margin:0; padding-top:3.5rem; background:#fff; }
-      header { position:fixed; top:0; left:0; right:0; background:#fff; border-bottom:1px solid #ccc; padding:.5rem; display:flex; flex-wrap:wrap; align-items:center; gap:.5rem; z-index:1000; }
+      header { position:fixed; top:0; left:50%; transform:translateX(-50%); width:100%; max-width:1800px; background:#fff; border-bottom:1px solid #ccc; padding:.5rem; display:flex; flex-wrap:wrap; align-items:center; gap:.5rem; z-index:1000; }
       header input[type=text], header input[type=file]{ flex:1; min-width:200px; }
       header button{ padding:.25rem .5rem; }
       header span#status { margin-left:1rem; font-size:.9rem; color:#555; }
-      main { padding:1rem; }
+      main { padding:1rem; max-width:1800px; margin:0 auto; }
       #summary { display:flex; flex-wrap:wrap; gap:1rem; margin-bottom:1rem; }
       .card { border:1px solid #ccc; border-radius:4px; padding:.5rem 1rem; min-width:120px; }
       table { width:100%; border-collapse:collapse; margin-top:1rem; }


### PR DESCRIPTION
## Summary
- cap coverage page content at 1800px and center on wide screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f9f18d68832a8c55a32e66899479