### PR TITLE
Add bottom spacing to coverage page

### DIFF
--- a/coverage/index.html
+++ b/coverage/index.html
@@ -13,7 +13,7 @@
       body, pre, code, input, button, select, textarea, header, main, div, span, table, th, td {
         font-family: '0xProto', monospace;
       }
-      body { margin:0; padding-top:3.5rem; background:#fff; }
+        body { margin:0; padding-top:3.5rem; padding-bottom:30vh; background:#fff; }
       header { position:fixed; top:0; left:50%; transform:translateX(-50%); width:100%; max-width:1800px; background:#fff; border-bottom:1px solid #ccc; padding:.5rem; display:flex; flex-wrap:wrap; align-items:center; gap:.5rem; z-index:1000; }
       header input[type=text], header input[type=file]{ flex:1; min-width:200px; }
       header button{ padding:.25rem .5rem; }


### PR DESCRIPTION
## Summary
- increase bottom padding on coverage index page to 30vh for ample space

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a3fbd11d14832ab3d0b43b85253ea3