### PR TITLE
Fix coverage source loading by generalizing commit lookup

### DIFF
--- a/coverage/index.html
+++ b/coverage/index.html
@@ -440,7 +440,8 @@
         const pathVal=pathInput.value.trim();
         if(!pathVal){ status('Path required'); filesData=[]; renderSummary(); renderTable(); return; }
         if(!params.get('srcRoot')){
-          const m=pathVal.match(/[\\/]([0-9a-f]{40})[\\/]lcov\.info(?:\.gz|\.xz)?$/);
+          // Match paths like {timestamp}.{commit_hash}.lcov.info or ...lcov.info.xz
+          const m=pathVal.match(/(?:^|\/)[^\/]+\.([0-9a-fA-F]{40})\.lcov\.info(?:\.xz)?$/);
           srcRoot = m ? `https://raw.githubusercontent.com/gluesql/gluesql/${m[1]}/` : '';
         }
         status('Loading...');


### PR DESCRIPTION
## Summary
- Extract commit hash from timestamped lcov filenames like `{timestamp}.{commit_hash}.lcov.info` or `.lcov.info.xz`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b680289c832ab663df5f87bc83bf