### PR TITLE
fix: handle encoded coverage paths

### DIFF
--- a/coverage/index.html
+++ b/coverage/index.html
@@ -437,11 +437,12 @@
       }
 
       async function load(){
-        const pathVal=pathInput.value.trim();
+        let pathVal=pathInput.value.trim();
         if(!pathVal){ status('Path required'); filesData=[]; renderSummary(); renderTable(); return; }
+        try{ pathVal = decodeURIComponent(pathVal); }catch{}
         if(!params.get('srcRoot')){
-          // Match paths like {timestamp}.{commit_hash}.lcov.info or ...lcov.info.xz
-          const m=pathVal.match(/(?:^|\/)[^\/]+\.([0-9a-fA-F]{40})\.lcov\.info(?:\.xz)?$/);
+          // Match commit hash in filenames like {timestamp}.{hash}.lcov.info or {hash}-lcov.info[.xz]
+          const m=pathVal.match(/([0-9a-fA-F]{40})(?=[^\/]*[.-]lcov\.info(?:\.xz)?$)/);
           srcRoot = m ? `https://raw.githubusercontent.com/gluesql/gluesql/${m[1]}/` : '';
         }
         status('Loading...');


### PR DESCRIPTION
## Summary
- support opening coverage reports with encoded paths
- detect commit hashes in hyphenated lcov filenames

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b6a89fa4832a8b3b6dd879ea6fd3